### PR TITLE
Memory Issue

### DIFF
--- a/EDSunriseSet.m
+++ b/EDSunriseSet.m
@@ -113,7 +113,7 @@ static const int secondsInHour= 60.0*60.0;
         _astronomicalTwilightEnd = nil;
         _astronomicalTwilightStart = nil;
         
-        _calendar = [[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar] autorelease];
+        _calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
         _utcTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
 
     }


### PR DESCRIPTION
EDSunriseSet objects will over-release it's `_calendar` ivar by `autoreleasing` it inside `init` and `releasing` it inside `dealloc`. This fixes it.
