### PR TITLE
fixed overrelease of ivar

### DIFF
--- a/EDSunriseSet.m
+++ b/EDSunriseSet.m
@@ -134,7 +134,6 @@ static const int secondsInHour= 60.0*60.0;
     [_civilTwilightStart release];
     [_nauticalTwilightEnd release];
     [_nauticalTwilightStart release];
-    [_nauticalTwilightEnd release];
     [_astronomicalTwilightEnd release];
     [_astronomicalTwilightStart release];
     [_calendar release];


### PR DESCRIPTION
In dealloc the _nauticalTwilightEnd ivar was released twice. If it was not nil the second release would cause EXC_BAD_ACCESS
