### PR TITLE
Turn on ARC in podspec.

### DIFF
--- a/EDSunriseSet.podspec
+++ b/EDSunriseSet.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.author       = { "Ernesto García" => "", "Paul Schlyter" => "pausch@stjarnhimlen.se" }
   s.source       = { :git => "https://github.com/erndev/EDSunriseSet.git", :tag => s.version.to_s }
   s.source_files = '*.{h,m}'
+  s.requires_arc = true
 end


### PR DESCRIPTION
The code has been ARCified but will now generate a build error when actually used as a pod. Turned on requires_arc to fix.
