### PR TITLE
Remove unused variable

### DIFF
--- a/EDSunriseSet.m
+++ b/EDSunriseSet.m
@@ -90,7 +90,6 @@
 
 @implementation EDSunriseSet
 
-static const int minutesInDay= 60.0*24.0;
 static const int secondsInHour= 60.0*60.0;
 
 #pragma mark - Initialization & dealloc


### PR DESCRIPTION
To fix Xcode's Unused Entity Issue warning
