### PR TITLE
Deprecation fixes for iOS8

### DIFF
--- a/EDSunriseSet.m
+++ b/EDSunriseSet.m
@@ -101,7 +101,7 @@ static const int secondsInHour= 60.0*60.0;
         self.longitude = longt;
         self.timezone = tz;        
         
-        self.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+        self.calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
         self.utcTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
 
     }


### PR DESCRIPTION
I've updated the library to be up-to-date with the deprecations that are part of iOS 8. As you may or may not know, EDSunriseSet will not work on iOS 8 due to the deprecations of particular calendar units and identifiers. These fixes are also backwards-compatible with previous iOS versions.
